### PR TITLE
XRT-1819: Changed transactionID to transaction for consistency

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -287,7 +287,7 @@ export default class Publish extends Extension {
                         `Publish '${parsedTopic.type}' '${key}' to '${re.name}' failed: '${error}'`;
                     logger.error(message);
                     logger.debug(error.stack);
-                    this.legacyLog({type: `zigbee_publish_error`, message, meta: {friendly_name: re.name}});
+                    this.legacyLog({type: `zigbee_publish_error`, message, meta: {friendly_name: re.name, transaction: transactionID}});
                 }
 
                 usedConverters[endpointOrGroupID].push(converter);

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -189,11 +189,11 @@ export default class Publish extends Extension {
                 }
                 toPublish[ID] = {...toPublish[ID], ...payload};
             };
-            const transactionID = new Map(entries).get('transactionID') ?? 0;
+            const transactionID = new Map(entries).get('transaction') ?? 0;
             session.set('givenTransactionID', transactionID);
 
             for (let [key, value] of entries) {
-                if (key === 'transactionID') continue;
+                if (key === 'transaction') continue;
                 let endpointName = parsedTopic.endpoint;
                 let localTarget = target;
                 let endpointOrGroupID = utils.isEndpoint(target) ? target.ID : target.groupID;
@@ -254,7 +254,7 @@ export default class Publish extends Extension {
                         const optimistic = !entitySettings.hasOwnProperty('optimistic') || entitySettings.optimistic;
                         if (result && result.state && optimistic) {
                             const msg = result.state;
-                            msg.transactionID = receivedTransactionID;
+                            msg.transaction = receivedTransactionID;
                             if (endpointName) {
                                 for (const key of Object.keys(msg)) {
                                     msg[`${key}_${endpointName}`] = msg[key];

--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -150,8 +150,8 @@ export default class Receive extends Extension {
                 logger.debug(error.stack);
             }
         }
-        if (data.type === 'attributeReport') payload.transactionID = -1;
-        else payload.transactionID = data.meta.zclTransactionSequenceNumber;
+        if (data.type === 'attributeReport') payload.transaction = -1;
+        else payload.transaction = data.meta.zclTransactionSequenceNumber;
         if (Object.keys(payload).length) {
             publish(payload);
         } else {


### PR DESCRIPTION
Changed "transactionID" key to "transaction" for consistency with existing implementation in bridge requests