### PR TITLE
XRT-1830: Decouple transaction IDs and convert readResponse early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Request ID functionality
   - Request IDs are taken from request and outputted alongside result.
-  - Required large amount of modification to convert read responses within onMqttMessage() handler.
+  - Passes read response data back to onMqttMessage() handler using cls-hooked.
+  - onMqttMessage() now finds and uses converters upon read responses.
   - In set requests, if no error is thrown a success response is now given
 - Cached values have now been removed from published responses.
 - Errors are now published to a device's topic, instead of only appearing in logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# v1.27
+
+- Request ID functionality
+  - Request IDs are taken from request and outputted alongside result.
+  - Required large amount of modification to convert read responses within onMqttMessage() handler.
+  - In set requests, if no error is thrown a success response is now given
+- Cached values have now been removed from published responses.
+- Errors are now published to a device's topic, instead of only appearing in logs.

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -116,195 +116,238 @@ export default class Publish extends Extension {
     }
 
     @bind async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
-        const createNameSpace = require('cls-hooked').createNamespace;
-        const session = createNameSpace('my session');
-        await session.run( async () => {
-            const parsedTopic = this.parseTopic(data.topic);
-            if (!parsedTopic) return;
+        const parsedTopic = this.parseTopic(data.topic);
+        if (!parsedTopic) return;
 
-            const re = this.zigbee.resolveEntity(parsedTopic.ID);
-            if (re == null) {
-                this.legacyLog({type: `entity_not_found`, message: {friendly_name: parsedTopic.ID}});
-                logger.error(`Entity '${parsedTopic.ID}' is unknown`);
-                return;
-            }
+        const re = this.zigbee.resolveEntity(parsedTopic.ID);
+        if (re == null) {
+            this.legacyLog({type: `entity_not_found`, message: {friendly_name: parsedTopic.ID}});
+            logger.error(`Entity '${parsedTopic.ID}' is unknown`);
+            return;
+        }
 
-            // Get entity details
-            const definition = re instanceof Device ? re.definition : re.membersDefinitions();
-            const target = re instanceof Group ? re.zh : re.endpoint(parsedTopic.endpoint);
-            if (target == null) {
-                logger.error(`Device '${re.name}' has no endpoint '${parsedTopic.endpoint}'`);
-                return;
+        // Get entity details
+        const definition = re instanceof Device ? re.definition : re.membersDefinitions();
+        const target = re instanceof Group ? re.zh : re.endpoint(parsedTopic.endpoint);
+        if (target == null) {
+            logger.error(`Device '${re.name}' has no endpoint '${parsedTopic.endpoint}'`);
+            return;
+        }
+        const device = re instanceof Device ? re.zh : null;
+        const entitySettings = re.options;
+        const entityState = this.state.get(re);
+        const membersState = re instanceof Group ?
+            Object.fromEntries(re.zh.members.map((e) => [e.getDevice().ieeeAddr,
+                this.state.get(this.zigbee.resolveEntity(e.getDevice().ieeeAddr))])) : null;
+        let converters: zhc.ToZigbeeConverter[];
+        {
+            if (Array.isArray(definition)) {
+                const c = new Set(definition.map((d) => d.toZigbee).flat());
+                if (c.size == 0) converters = defaultGroupConverters;
+                else converters = Array.from(c);
+            } else if (definition) {
+                converters = definition.toZigbee;
+            } else {
+                converters = [zigbeeHerdsmanConverters.toZigbeeConverters.read,
+                    zigbeeHerdsmanConverters.toZigbeeConverters.write];
             }
-            const device = re instanceof Device ? re.zh : null;
-            const entitySettings = re.options;
-            const entityState = this.state.get(re);
-            const membersState = re instanceof Group ?
-                Object.fromEntries(re.zh.members.map((e) => [e.getDevice().ieeeAddr,
-                    this.state.get(this.zigbee.resolveEntity(e.getDevice().ieeeAddr))])) : null;
-            let converters: zhc.ToZigbeeConverter[];
-            {
-                if (Array.isArray(definition)) {
-                    const c = new Set(definition.map((d) => d.toZigbee).flat());
-                    if (c.size == 0) converters = defaultGroupConverters;
-                    else converters = Array.from(c);
-                } else if (definition) {
-                    converters = definition.toZigbee;
-                } else {
-                    converters = [zigbeeHerdsmanConverters.toZigbeeConverters.read,
-                        zigbeeHerdsmanConverters.toZigbeeConverters.write];
+        }
+
+        // Convert the MQTT message to a Zigbee message.
+        const message = this.parseMessage(parsedTopic, data);
+        if (message == null) {
+            logger.error(`Invalid message '${message}', skipping...`);
+            return;
+        }
+        this.updateMessageHomeAssistant(message, entityState);
+
+        /**
+         * Order state & brightness based on current bulb state
+         *
+         * Not all bulbs support setting the color/color_temp while it is off
+         * this results in inconsistant behavior between different vendors.
+         *
+         * bulb on => move state & brightness to the back
+         * bulb off => move state & brightness to the front
+         */
+        const entries = Object.entries(message);
+        const sorter = typeof message.state === 'string' && message.state.toLowerCase() === 'off' ? 1 : -1;
+        entries.sort((a) => (['state', 'brightness', 'brightness_percent'].includes(a[0]) ? sorter : sorter * -1));
+
+        // For each attribute call the corresponding converter
+        const usedConverters: { [s: number]: zhc.ToZigbeeConverter[] } = {};
+        const toPublish: { [s: number | string]: KeyValue } = {};
+        const toPublishEntity: { [s: number | string]: Device | Group } = {};
+        const requestID: number = +new Map(entries).get('request');
+        let returnMap: {[s: string]: string | number | boolean} = {request: requestID};
+        const addToToPublish = (entity: Device | Group, payload: KeyValue): void => {
+            const ID = entity.ID;
+            if (!(ID in toPublish)) {
+                toPublish[ID] = {};
+                toPublishEntity[ID] = entity;
+            }
+            toPublish[ID] = {...toPublish[ID], ...payload};
+        };
+
+        for (let [key, value] of entries) {
+            if (key === 'request') continue;
+            let endpointName = parsedTopic.endpoint;
+            let localTarget = target;
+            let endpointOrGroupID = utils.isEndpoint(target) ? target.ID : target.groupID;
+
+            // When the key has a endpointName included (e.g. state_right), this will override the target.
+            const propertyEndpointMatch = key.match(propertyEndpointRegex);
+            if (re instanceof Device && propertyEndpointMatch) {
+                endpointName = propertyEndpointMatch[2];
+                key = propertyEndpointMatch[1];
+                localTarget = re.endpoint(endpointName);
+                if (localTarget == null) {
+                    logger.error(`Device '${re.name}' has no endpoint '${endpointName}'`);
+                    continue;
                 }
+                endpointOrGroupID = localTarget.ID;
             }
 
-            // Convert the MQTT message to a Zigbee message.
-            const message = this.parseMessage(parsedTopic, data);
-            if (message == null) {
-                logger.error(`Invalid message '${message}', skipping...`);
-                return;
+            if (!usedConverters.hasOwnProperty(endpointOrGroupID)) usedConverters[endpointOrGroupID] = [];
+            const converter = converters.find((c) => c.key.includes(key));
+
+            if (parsedTopic.type === 'set' && usedConverters[endpointOrGroupID].includes(converter)) {
+                // Use a converter for set only once
+                // (e.g. light_onoff_brightness converters can convert state and brightness)
+                continue;
             }
-            this.updateMessageHomeAssistant(message, entityState);
 
-            /**
-             * Order state & brightness based on current bulb state
-             *
-             * Not all bulbs support setting the color/color_temp while it is off
-             * this results in inconsistant behavior between different vendors.
-             *
-             * bulb on => move state & brightness to the back
-             * bulb off => move state & brightness to the front
-             */
-            const entries = Object.entries(message);
-            const sorter = typeof message.state === 'string' && message.state.toLowerCase() === 'off' ? 1 : -1;
-            entries.sort((a) => (['state', 'brightness', 'brightness_percent'].includes(a[0]) ? sorter : sorter * -1));
+            if (!converter) {
+                logger.error(`No converter available for '${key}' (${stringify(message[key])})`);
+                continue;
+            }
 
-            // For each attribute call the corresponding converter
-            const usedConverters: { [s: number]: zhc.ToZigbeeConverter[] } = {};
-            const toPublish: { [s: number | string]: KeyValue } = {};
-            const toPublishEntity: { [s: number | string]: Device | Group } = {};
-            const addToToPublish = (entity: Device | Group, payload: KeyValue): void => {
-                const ID = entity.ID;
-                if (!(ID in toPublish)) {
-                    toPublish[ID] = {};
-                    toPublishEntity[ID] = entity;
-                }
-                toPublish[ID] = {...toPublish[ID], ...payload};
-            };
-            const transactionID = new Map(entries).get('transaction') ?? 0;
-            session.set('givenTransactionID', transactionID);
+            // If the endpoint_name name is a nubmer, try to map it to a friendlyName
+            if (!isNaN(Number(endpointName)) && re.isDevice() && utils.isEndpoint(localTarget) &&
+                re.endpointName(localTarget)) {
+                endpointName = re.endpointName(localTarget);
+            }
 
-            for (let [key, value] of entries) {
-                if (key === 'transaction') continue;
-                let endpointName = parsedTopic.endpoint;
-                let localTarget = target;
-                let endpointOrGroupID = utils.isEndpoint(target) ? target.ID : target.groupID;
+            // Converter didn't return a result, skip
+            const meta = {endpoint_name: endpointName, options: entitySettings, message: {...message}, logger, device,
+                state: entityState, membersState, mapped: definition};
 
-                // When the key has a endpointName included (e.g. state_right), this will override the target.
-                const propertyEndpointMatch = key.match(propertyEndpointRegex);
-                if (re instanceof Device && propertyEndpointMatch) {
-                    endpointName = propertyEndpointMatch[2];
-                    key = propertyEndpointMatch[1];
-                    localTarget = re.endpoint(endpointName);
-                    if (localTarget == null) {
-                        logger.error(`Device '${re.name}' has no endpoint '${endpointName}'`);
-                        continue;
+            // Strip endpoint name from meta.message properties.
+            if (endpointName) {
+                for (const [key, value] of Object.entries(meta.message)) {
+                    if (key.endsWith(endpointName)) {
+                        delete meta.message[key];
+                        const keyWithoutEndpoint = key.substring(0, key.length - endpointName.length - 1);
+                        meta.message[keyWithoutEndpoint] = value;
                     }
-                    endpointOrGroupID = localTarget.ID;
                 }
+            }
+            try {
+                if (parsedTopic.type === 'set' && converter.convertSet) {
+                    logger.debug(`Publishing '${parsedTopic.type}' '${key}' to '${re.name}'`);
+                    const result = await converter.convertSet(localTarget, key, value, meta);
+                    if (result) returnMap['successful'] = true;
+                    const optimistic = !entitySettings.hasOwnProperty('optimistic') || entitySettings.optimistic;
+                    if (result && result.state && optimistic) {
+                        const msg = result.state;
 
-                if (!usedConverters.hasOwnProperty(endpointOrGroupID)) usedConverters[endpointOrGroupID] = [];
-                const converter = converters.find((c) => c.key.includes(key));
+                        if (endpointName) {
+                            for (const key of Object.keys(msg)) {
+                                msg[`${key}_${endpointName}`] = msg[key];
+                                delete msg[key];
+                            }
+                        }
 
-                if (parsedTopic.type === 'set' && usedConverters[endpointOrGroupID].includes(converter)) {
-                    // Use a converter for set only once
-                    // (e.g. light_onoff_brightness converters can convert state and brightness)
-                    continue;
-                }
+                        // filter out attribute listed in filtered_optimistic
+                        utils.filterProperties(entitySettings.filtered_optimistic, msg);
 
-                if (!converter) {
-                    logger.error(`No converter available for '${key}' (${stringify(message[key])})`);
-                    continue;
-                }
+                        addToToPublish(re, msg);
+                    }
 
-                // If the endpoint_name name is a nubmer, try to map it to a friendlyName
-                if (!isNaN(Number(endpointName)) && re.isDevice() && utils.isEndpoint(localTarget) &&
-                    re.endpointName(localTarget)) {
-                    endpointName = re.endpointName(localTarget);
-                }
-
-                // Converter didn't return a result, skip
-                const meta = {endpoint_name: endpointName, options: entitySettings, message: {...message}, logger, device,
-                    state: entityState, membersState, mapped: definition};
-
-                // Strip endpoint name from meta.message properties.
-                if (endpointName) {
-                    for (const [key, value] of Object.entries(meta.message)) {
-                        if (key.endsWith(endpointName)) {
-                            delete meta.message[key];
-                            const keyWithoutEndpoint = key.substring(0, key.length - endpointName.length - 1);
-                            meta.message[keyWithoutEndpoint] = value;
+                    if (result && result.membersState && optimistic) {
+                        for (const [ieeeAddr, state] of Object.entries(result.membersState)) {
+                            addToToPublish(this.zigbee.resolveEntity(ieeeAddr), state);
                         }
                     }
-                }
+                    this.legacyRetrieveState(re, converter, result, localTarget, key, meta);
+                } else if (parsedTopic.type === 'get' && converter.convertGet) {
+                    logger.debug(`Publishing get '${parsedTopic.type}' '${key}' to '${re.name}'`);
+                    const createNameSpace = require('cls-hooked').createNamespace;
+                    const session = createNameSpace('my session');
+                    returnMap = await session.runAndReturn(async () => {
+                        await converter.convertGet(localTarget, key, meta);
+                        const msg = session.get('returnMessage');
+                        const foundPayload = msg.frame.Payload;
+                        const returnCluster = session.get('returnCluster');
+                        const returnAttributes = session.get('returnAttributes');
+                        const constructedData: KeyValue | Array<string | number> = {};
+                        if (foundPayload.length != returnAttributes.length) {
+                            throw new Error('Return payload in unexpected format');
+                        }
+                        for (let i = 0; i < foundPayload.length; i++) {
+                            let foundVal = foundPayload[i].attrData;
+                            constructedData[returnAttributes[i]] = foundVal;
+                            const msgType = 'readResponse';
 
-                try {
-                    if (parsedTopic.type === 'set' && converter.convertSet) {
-                        logger.debug(`Publishing '${parsedTopic.type}' '${key}' to '${re.name}'`);
-                        const result = await converter.convertSet(localTarget, key, value, meta);
-                        const receivedTransactionID = session.get('receivedTransactionID');
-                        const optimistic = !entitySettings.hasOwnProperty('optimistic') || entitySettings.optimistic;
-                        if (result && result.state && optimistic) {
-                            const msg = result.state;
-                            msg.transaction = receivedTransactionID;
-                            if (endpointName) {
-                                for (const key of Object.keys(msg)) {
-                                    msg[`${key}_${endpointName}`] = msg[key];
-                                    delete msg[key];
+                            const constructedMsg: eventdata.DeviceMessage = {
+                                type: msgType,
+                                // Will need to be changed for groups
+                                device: re instanceof Device ? re : null,
+                                endpoint: re instanceof Device ? re.endpoint(msg.endpoint) : null,
+                                linkquality: msg.linkquality,
+                                groupID: msg.groupID,
+                                cluster: returnCluster,
+                                data: constructedData,
+                                meta: {zclTransactionSequenceNumber: msg.frame.Header.transactionSequenceNumber},
+                            };
+                            const emptyPublish = (payload: KeyValue): void => {
+                            };
+                            let revConverters;
+                            if (!(re instanceof Group)) {
+                                revConverters = zigbeeHerdsmanConverters.findByDevice(re.zh).fromZigbee.filter((c) => {
+                                    const type = Array.isArray(c.type) ? c.type.includes(msgType) : c.type === msgType;
+                                    return c.cluster === returnCluster.name && type;
+                                });
+                            }
+                            for (const revConverter of revConverters) {
+                                try {
+                                    const revConverted = await revConverter.convert(
+                                        re instanceof Device ? re.definition : null, constructedMsg, emptyPublish, re.options, meta);
+                                    if (revConverted) foundVal = {...foundVal, ...revConverted};
+                                } catch (error) /* istanbul ignore next */ {
+                                    logger.error(`Exception while calling fromZigbee converter: ${error.message}}`);
+                                    logger.debug(error.stack);
                                 }
                             }
-
-                            // filter out attribute listed in filtered_optimistic
-                            utils.filterProperties(entitySettings.filtered_optimistic, msg);
-
-                            addToToPublish(re, msg);
+                            returnMap = {...returnMap, ...foundVal};
                         }
-
-                        if (result && result.membersState && optimistic) {
-                            for (const [ieeeAddr, state] of Object.entries(result.membersState)) {
-                                addToToPublish(this.zigbee.resolveEntity(ieeeAddr), state);
-                            }
-                        }
-
-                        this.legacyRetrieveState(re, converter, result, localTarget, key, meta);
-                    } else if (parsedTopic.type === 'get' && converter.convertGet) {
-                        logger.debug(`Publishing get '${parsedTopic.type}' '${key}' to '${re.name}'`);
-                        await converter.convertGet(localTarget, key, meta);
-                    } else {
-                        logger.error(`No converter available for '${parsedTopic.type}' '${key}' (${message[key]})`);
-                        continue;
-                    }
-                } catch (error) {
-                    const message =
-                        `Publish '${parsedTopic.type}' '${key}' to '${re.name}' failed: '${error}'`;
-                    logger.error(message);
-                    logger.debug(error.stack);
-                    // this.legacyLog({type: `zigbee_publish_error`, message, meta: {friendly_name: re.name, transaction: transactionID}});
-                    addToToPublish(re, {error: message, transaction: transactionID});
+                        return returnMap;
+                    });
+                } else {
+                    logger.error(`No converter available for '${parsedTopic.type}' '${key}' (${message[key]})`);
+                    continue;
                 }
-
-                usedConverters[endpointOrGroupID].push(converter);
+            } catch (error) {
+                const message =
+                    `Publish '${parsedTopic.type}' '${key}' to '${re.name}' failed: '${error}'`;
+                logger.error(message);
+                logger.debug(error.stack);
+                await this.mqtt.publish(re.name, stringify(
+                    {request: requestID, error: message}), {},
+                );
             }
-
-            for (const [ID, payload] of Object.entries(toPublish)) {
-                if (Object.keys(payload).length != 0) {
-                    this.publishEntityState(toPublishEntity[ID], payload);
-                }
+            usedConverters[endpointOrGroupID].push(converter);
+        }
+        for (const [ID, payload] of Object.entries(toPublish)) {
+            if (Object.keys(payload).length != 0) {
+                this.publishEntityState(toPublishEntity[ID], payload);
             }
-
-            const scenesChanged = Object.values(usedConverters)
-                .some((cl) => cl.some((c) => c.key.some((k) => sceneConverterKeys.includes(k))));
-            if (scenesChanged) {
-                this.eventBus.emitScenesChanged();
-            }
-        });
+        }
+        const scenesChanged = Object.values(usedConverters)
+            .some((cl) => cl.some((c) => c.key.some((k) => sceneConverterKeys.includes(k))));
+        if (scenesChanged) {
+            this.eventBus.emitScenesChanged();
+        }
+        if (Object.keys(returnMap).length > 1) await this.mqtt.publish(re.name, stringify(returnMap), {});
     }
 }

--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -91,6 +91,8 @@ export default class Receive extends Extension {
         /* istanbul ignore next */
         if (!data.device) return;
 
+        if(data.type != 'attributeReport') return;
+
         if (!this.shouldProcess(data)) {
             utils.publishLastSeen({device: data.device, reason: 'messageEmitted'},
                 settings.get(), true, this.publishEntityState);
@@ -150,10 +152,9 @@ export default class Receive extends Extension {
                 logger.debug(error.stack);
             }
         }
-        if (data.type === 'attributeReport') payload.transaction = -1;
-        else payload.transaction = data.meta.zclTransactionSequenceNumber;
         if (Object.keys(payload).length) {
-            publish(payload);
+            payload['isReport'] = true;
+            await this.mqtt.publish(data.device.name, stringify(payload), {});
         } else {
             utils.publishLastSeen({device: data.device, reason: 'messageEmitted'},
                 settings.get(), true, this.publishEntityState);


### PR DESCRIPTION
No longer passes transaction IDs to zigbee-herdsman which means that request IDs from xrt will no longer determine transaction IDs set by herdsman. Read response data is also now brought in early using cls-hooked and passed through converters. This means that we can tie a response to the correct request ID. Output from zigbee2mqtt also reduced and no longer includes cached values.