### PR TITLE
XRT-1819: Small fix to correctly display successful sets

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -247,12 +247,10 @@ export default class Publish extends Extension {
                 if (parsedTopic.type === 'set' && converter.convertSet) {
                     logger.debug(`Publishing '${parsedTopic.type}' '${key}' to '${re.name}'`);
                     const result = await converter.convertSet(localTarget, key, value, meta);
-                    if (result) {
-                        let prev : string[] = [];
-                        if (returnMap.hasOwnProperty('successful')) prev = <string[]>returnMap['successful'];
-                        prev.push(key);
-                        returnMap['successful'] = prev;
-                    }
+                    let prev : string[] = [];
+                    if (returnMap.hasOwnProperty('successful')) prev = <string[]>returnMap['successful'];
+                    prev.push(key);
+                    returnMap['successful'] = prev;
                     const optimistic = !entitySettings.hasOwnProperty('optimistic') || entitySettings.optimistic;
                     if (result && result.state && optimistic) {
                         const msg = result.state;


### PR DESCRIPTION
Fixed some exposes not showing as successful due to differing return value from converters. Now if no error is caught, then assume success.